### PR TITLE
Routing Guide

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -18,7 +18,7 @@ After reading this guide, you will know:
 The Purpose of the Rails Router
 -------------------------------
 
-The Rails router recognizes URLs and dispatches them to a controller's action, or to a Rack application. It can also generate paths and URLs, avoiding the need to hardcode strings in your views.
+The Rails router dispatches incoming HTTP requests to your Rails application to specific controller actions based on the URL path. (It can also dispatch to a Rack application.) It can also generate paths and URLs, avoiding the need to hardcode strings in your views.
 
 ### Connecting URLs to Code
 


### PR DESCRIPTION
- [ ] We mention Rack application right away, good place to link to the [Rack guide](https://edgeguides.rubyonrails.org/rails_on_rack.html).
- [ ] Would it make sense to link "CRUD operation" to something like the [AR Basics CRUD](https://edgeguides.rubyonrails.org/active_record_basics.html#crud-reading-and-writing-data) section? We don't _always_ need to tie CRUD to database, it's more about the concept.
- [ ] Under Path and URL helpers, it might make sense to turn that list into a table to make it easier to scan?
- [ ] Singular resources starts with examples of using get, maybe it should be specific to resource and leave get to Non-Resourceful Routes section? That section doesn't start with "simple" examples.
- [ ] "Because you might want to use the same controller for a singular route (/account) and a plural route (/accounts/45), singular resources map to plural controllers." => I've never seen this be the case, I think this can be reworded to explain that singular resources map to plural controllers, without this idea of "use the same controller".
- [ ] Under shallow nesting, there's a long example with three child resources to demonstrante that "all get the same shallow behavior"... maybe that'd be better with just 2 so that the table doesn't get so big/long.
- [ ] Under creating paths and URLs from objects, it explains how to create paths from objects (i.e. polymorphic routing), that may be a good segway to show that it uses the route key / singular route key from ActiveModel::Naming to figure that out. (could be a note/tip of sorts for example, just thought it'd be good to make that connection somewhere) Also ActiveModel::Conversion#to_param would be used to convert the IDs.
- [ ] member and collection are explained under "Adding more RESTful actions", but there's not a good clarification of what the terms represent, i.e. that member refers to routes acting on a single element, much like show/update/destroy, and collection referes to routes acting on multiple (or a collection of) elements like index. Is it worth clarifying further?
- [ ] Consider: Constraints could be a main section rather than live under non-resourceful routes, because generally speaking, they can be applied anywhere, even for resources. The only specific one would be match...via:
- [ ] Under Route Globbing and Wildcard Segments there's a waning about passing format: false related to "old 3.0.x behavior" which can either be explained better (what's the meaning of passing format: false), and/or potentially removed (at least the mention to "3.0.x behavior" could be removed) 
- [ ] When explaining about using draw to break down very large route files, that subsection could be a caution/warning of sorts to call more attention to the fact that most people shouldn't need it.
- [ ] We could explain how to check routes via console with Rails.application.routes.url_helpers under inspecting routes.
- [ ] Document the somewhat recent `--unused` option to rails routes. ([Reference](https://github.com/rails/rails/pull/51316#issuecomment-1994428608))